### PR TITLE
Add test: Expression using `this` is not constant

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,9 @@ describe('isConstant(src)', function () {
   it('handles "Math.floor(10.5)" with {Math: Math} as constants', function () {
     assert(constaninople.isConstant('Math.floor(10.5)', {Math: Math}) === true)
   })
+  it('handles "this.myVar"', function () {
+    assert(constaninople.isConstant('this.myVar') === false)
+  })
 })
 
 


### PR DESCRIPTION
I think it is reasonable to think that constantinople should return false when `this` is used in an expression
