### PR TITLE
Fix #1: An expression using `this` is not constant

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,5 +36,19 @@ function detect(src) {
     .map(function (node, name) {
       return name
     })
+  
+  // Walk the AST tree in search for `this`
+  // Add a fake "this" global when found
+  var has_this = false;
+  var walker = new uglify.TreeWalker(function(node) {
+    if (node instanceof uglify.AST_This) {
+      has_this = true;
+    }
+  });
+  ast.walk(walker);
+  if (has_this) {
+    globals.push('this')
+  }
+  
   return globals
 }


### PR DESCRIPTION
Maybe you will find another way to fix this.
I did not find :
- an uglifyjs API that could answer the has(AST_This) question
- a way to stop the walking upon the first AST_This found

Throwing an exception could be an idea since it would return false but "goto as an exception" is rarely the best option ;-)

I hope you will agree with me that "this.myVar" is not constant ! this is done in order to allow 

```
div(onClick=this.handleClick)
```

in `react-jade` so that we can have more real-life components (`this` scope in the `render` function is heavily used to reference the component instances (this.functions, this.props, this.state)
