### PR TITLE
SpreadProperty renamed to SpreadElement in babel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export function expressionToConstant(
           }
         } else if (b.isObjectMethod(property)) {
           constant = false;
-        } else if (b.isSpreadProperty(property)) {
+        } else if (b.isSpreadElement(property)) {
           const argument = toConstant(property.argument);
           if (!argument) constant = false;
           if (!constant) return;


### PR DESCRIPTION
SpreadProperty renamed to SpreadElement see https://github.com/babel/babel/blob/df733b18ae88f370caddecc30c6d96844007c411/packages/babel-types/src/validators/generated/index.ts#L5846 

this causes errors like
```
console.error
Trace: The node type SpreadProperty has been renamed to SpreadElement
at Object.trace (node_modules/@babel/types/src/validators/generated/index.ts:5845:11)
at toConstant (node_modules/constantinople/lib/index.js:177:28)
at toConstant (node_modules/constantinople/lib/index.js:56:31)
at toConstant (node_modules/constantinople/lib/index.js:36:25)
at expressionToConstant (node_modules/constantinople/lib/index.js:237:18)
at isConstant (node_modules/constantinople/lib/index.js:349:14)
at isConstant (node_modules/pug-code-gen/index.js:36:10)
at Compiler.bufferExpression (node_modules/pug-code-gen/index.js:242:9)
at Compiler.attrs (node_modules/pug-code-gen/index.js:978:12)
at Compiler.visitAttributes (node_modules/pug-code-gen/index.js:963:12)
at Compiler.visitTag (node_modules/pug-code-gen/index.js:670:12)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.visitBlock (node_modules/pug-code-gen/index.js:446:12)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.visitMixin (node_modules/pug-code-gen/index.js:596:12)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.visitBlock (node_modules/pug-code-gen/index.js:446:12)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.visitBlock (node_modules/pug-code-gen/index.js:446:12)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.visitBlock (node_modules/pug-code-gen/index.js:446:12)
at Compiler.visitNamedBlock (node_modules/pug-code-gen/index.js:411:17)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.visitBlock (node_modules/pug-code-gen/index.js:446:12)
at Compiler.visitNode (node_modules/pug-code-gen/index.js:364:37)
at Compiler.visit (node_modules/pug-code-gen/index.js:353:10)
at Compiler.compile (node_modules/pug-code-gen/index.js:113:10)
at generateCode (node_modules/pug-code-gen/index.js:32:37)
at compileBody (node_modules/pug/lib/index.js:199:74)
at Object.<anonymous>.exports.compile (node_modules/pug/lib/index.js:269:16)
at handleTemplateCache (node_modules/pug/lib/index.js:242:25)
at Object.<anonymous>.exports.renderFile (node_modules/pug/lib/index.js:454:10)
at Object.<anonymous>.exports.renderFile (node_modules/pug/lib/index.js:444:21)
at View.Object.<anonymous>.exports.__express [as engine] (node_modules/pug/lib/index.js:493:11)
at View.render (node_modules/express/lib/view.js:135:8)
at tryRender (node_modules/express/lib/application.js:640:10)
at Function.render (node_modules/express/lib/application.js:592:3)
at ServerResponse.render (node_modules/express/lib/response.js:1017:7)
at Generator.next (<anonymous>)
```